### PR TITLE
Do not fail when trying to parse unknown value reporesented by enum

### DIFF
--- a/src/main/java/com/github/vjuranek/beaker4j/remote_model/BeakerTask.java
+++ b/src/main/java/com/github/vjuranek/beaker4j/remote_model/BeakerTask.java
@@ -81,8 +81,8 @@ public class BeakerTask extends RemoteBeakerObject {
             this.isFailed = (Boolean)taskInfo.get(FAILED_FIELD);
             this.isFinished = (Boolean)taskInfo.get(FINISHED_FIELD);
             this.stateLabel = (String)taskInfo.get(LABEL_FIELD);
-            this.state = TaskStatus.valueOf(((String)taskInfo.get(STATE_FIELD)).toUpperCase());
-            this.result = TaskResult.valueOf(((String)taskInfo.get(RESULT_FIELD)).toUpperCase());
+            this.state = TaskStatus.fromString(((String)taskInfo.get(STATE_FIELD)).toUpperCase());
+            this.result = TaskResult.fromString(((String)taskInfo.get(RESULT_FIELD)).toUpperCase());
             //TODO check for null - NPE: at org.fedorahosted.beaker4j.remote_model.BeakerTask$Worker.<init>(BeakerTask.java:188)
             //this.worker = new Worker((Map<String,String>)taskInfo.get(WORKER_FIELD)); 
         }

--- a/src/main/java/com/github/vjuranek/beaker4j/remote_model/TaskResult.java
+++ b/src/main/java/com/github/vjuranek/beaker4j/remote_model/TaskResult.java
@@ -1,10 +1,12 @@
 package com.github.vjuranek.beaker4j.remote_model;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
- * See TaskResult class in <a href="https://github.com/beaker-project/beaker/blob/develop/Server/bkr/server/model.py">model.py</a>
- * @see <a href="https://github.com/beaker-project/beaker/blob/develop/Server/bkr/server/model.py">model.py</a>
- * @author vjuranek
+ * Result of a Beaker task.
  *
+ * @see <a href="https://github.com/beaker-project/beaker/blob/master/Server/bkr/server/model/types.py">https://github.com/beaker-project/beaker/blob/master/Server/bkr/server/model/types.py</a>
  */
 public enum TaskResult {
     
@@ -13,6 +15,15 @@ public enum TaskResult {
     WARN,
     FAIL,
     PANIC,
-    NONE;
-    
+    NONE,
+    UNKNOWN; // Client failed to understand the status
+
+    public static TaskResult fromString(String s) {
+        try {
+            return valueOf(s);
+        } catch (IllegalArgumentException ex) {
+            Logger.getLogger(TaskStatus.class.getName()).log(Level.SEVERE, "Unable to parse TaskResult from " + s);
+        }
+        return UNKNOWN;
+    }
 }

--- a/src/main/java/com/github/vjuranek/beaker4j/remote_model/TaskResult.java
+++ b/src/main/java/com/github/vjuranek/beaker4j/remote_model/TaskResult.java
@@ -22,7 +22,7 @@ public enum TaskResult {
         try {
             return valueOf(s);
         } catch (IllegalArgumentException ex) {
-            Logger.getLogger(TaskStatus.class.getName()).log(Level.SEVERE, "Unable to parse TaskResult from " + s);
+            Logger.getLogger(TaskStatus.class.getName()).log(Level.SEVERE, "Unable to parse TaskResult from " + s, ex);
         }
         return UNKNOWN;
     }

--- a/src/main/java/com/github/vjuranek/beaker4j/remote_model/TaskStatus.java
+++ b/src/main/java/com/github/vjuranek/beaker4j/remote_model/TaskStatus.java
@@ -1,11 +1,13 @@
 package com.github.vjuranek.beaker4j.remote_model;
 
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
- * See TaskStatus class in <a href="https://github.com/beaker-project/beaker/blob/develop/Server/bkr/server/model.py">model.py</a>
- * @see <a href="https://github.com/beaker-project/beaker/blob/develop/Server/bkr/server/model.py">model.py</a>
- * @author vjuranek
+ * Status of a beaker task.
  *
+ * @see <a href="https://github.com/beaker-project/beaker/blob/master/Server/bkr/server/model/types.py">https://github.com/beaker-project/beaker/blob/master/Server/bkr/server/model/types.py</a>
  */
 public enum TaskStatus {
 
@@ -14,9 +16,20 @@ public enum TaskStatus {
     QUEUED,
     SCHEDULED,
     WAITING,
+    INSTALLING,
     RUNNING,
+    RESERVED,
     COMPLETED,
     CANCELLED,
-    ABORTED;
-    
+    ABORTED,
+    UNKNOWN; // Client failed to understand the status
+
+    public static TaskStatus fromString(String s) {
+        try {
+            return valueOf(s);
+        } catch (IllegalArgumentException ex) {
+            Logger.getLogger(TaskStatus.class.getName()).log(Level.SEVERE, "Unable to parse TaskStatus from " + s);
+        }
+        return UNKNOWN;
+    }
 }

--- a/src/main/java/com/github/vjuranek/beaker4j/remote_model/TaskStatus.java
+++ b/src/main/java/com/github/vjuranek/beaker4j/remote_model/TaskStatus.java
@@ -28,7 +28,7 @@ public enum TaskStatus {
         try {
             return valueOf(s);
         } catch (IllegalArgumentException ex) {
-            Logger.getLogger(TaskStatus.class.getName()).log(Level.SEVERE, "Unable to parse TaskStatus from " + s);
+            Logger.getLogger(TaskStatus.class.getName()).log(Level.SEVERE, "Unable to parse TaskStatus from " + s, ex);
         }
         return UNKNOWN;
     }


### PR DESCRIPTION
Beaker added a couple of more task statuses lately and client fail to parse it as `Enum.valueOf` throws `IllegalArgumentException` in case the reported value do not have its counterpart declared in the client. This change
- Add new statuses (both statuses and results should be up to date with beaker sources)
- Introduces `UNKNOWN` member for all enums based domain objects that will be used in case client does not understand server's  reply.
